### PR TITLE
input tweaks

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Input as ThemedInput } from 'theme-ui'
 import getSizeStyles from './utils/get-size-styles'
 
-const Input = ({ size, inverted, sx, align, ...props }) => {
+const Input = ({ size = 'sm', inverted, sx, ...props }) => {
   const defaultColor = inverted ? 'secondary' : 'primary'
 
   const styles = {
@@ -12,11 +12,12 @@ const Input = ({ size, inverted, sx, align, ...props }) => {
     borderWidth: '0px',
     borderBottomWidth: '1px',
     borderRadius: '0px',
-    transition: '0.15s',
+    transition: 'border 0.15s',
     borderBottomWidth: '1px',
-    lineHeight: 1.05,
-    p: [1, 1, 1],
-    pl: [0, 0, 0],
+    lineHeight: 1.2,
+    width: 'calc(min(15ch, 100%))',
+    p: [0],
+    py: ['2px'],
     'input::-webkit-outer-spin-button': {
       WebkitAppearance: 'none',
       margin: 0,


### PR DESCRIPTION
This PR tweaks the new `Input` component in a few small but hopefully useful ways (screenshots below).
- Sets a default arg for size (was raising an error before, now it's matched to the default for `Button`)
- Increases the line height and decreases the padding (see more on why below)
- Uses a character based default width that scales with the font size (often we'll override the width anyway, but this feels like a more sensible default?)
- Uses one number for padding (which I confirmed allows either a singleton or array specification of padding to override)

The main thing to highlight here is the line height. The line height we had of 1.05 was clipping the lowest descenders (look at the "g" in the before and after below). I'm fairly certain this was causing the difference between Chrome and Safari, because Safari was forcing the size to accommodate the maximum character height, whereas Chrome was clipping (and scrolling). I also think this combination of line height and padding achieves a cleaner look across the sizes.

From testing, I think we can get the same alignment we wanted in the two places we use this component (maybe by tweaking the padding). And this feels version more reliable in terms of cross-browser rendering.

Comments welcome!

Before:
<img width="696" alt="CleanShot 2021-07-18 at 14 39 18@2x" src="https://user-images.githubusercontent.com/3387500/126083119-d5ca5b32-15ba-4e55-90d8-d664edf61bf9.png">

After:
<img width="696" alt="CleanShot 2021-07-18 at 14 37 02@2x" src="https://user-images.githubusercontent.com/3387500/126083156-66575bbc-7bf8-4feb-be9e-4ba783e7d5bd.png">
