### PR TITLE
Standardize content mb in Layout

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -32,7 +32,11 @@ const Layout = ({
     content = <FadeIn duration={250}>{content}</FadeIn>
   }
   if (container) {
-    content = <Container>{content}</Container>
+    content = (
+      <Box id='testing' sx={{ mb: [8, 8, 9, 10] }}>
+        <Container>{content}</Container>
+      </Box>
+    )
   }
 
   return (

--- a/src/layout.js
+++ b/src/layout.js
@@ -33,7 +33,7 @@ const Layout = ({
   }
   if (container) {
     content = (
-      <Box id='testing' sx={{ mb: [8, 8, 9, 10] }}>
+      <Box sx={{ mb: [8, 8, 9, 10] }}>
         <Container>{content}</Container>
       </Box>
     )


### PR DESCRIPTION
- consolidates pattern for margin at bottom of page content
- allows us to clean up remove this configuration from quite a few places
  - carbonplan.org: [diff](https://github.com/carbonplan/carbonplan.org/compare/katamartin/components-update?expand=1&w=1), [staging](https://carbonplanorg-6ezrsjsk5-carbonplan.vercel.app/)
  - research: [diff](https://github.com/carbonplan/research/compare/katamartin/components-update?expand=1), [staging](https://research-qenqm2o8x-carbonplan.vercel.app/research)
  - design: [diff](https://github.com/carbonplan/design/compare/katamartin/components-update?expand=1), [staging](https://design-nszrqdxh6-carbonplan.vercel.app/)

