### PR TITLE
add ref forwarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/components",
-  "version": "10.6.0",
+  "version": "10.5.0",
   "description": "shared components for our websites",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/components",
-  "version": "10.5.0",
+  "version": "10.6.0",
   "description": "shared components for our websites",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/src/button.js
+++ b/src/button.js
@@ -1,21 +1,24 @@
-import React, { cloneElement } from 'react'
+import React, { forwardRef, cloneElement } from 'react'
 import { Box } from 'theme-ui'
 import Link from './link'
 import getSizeStyles from './utils/get-size-styles'
 
-const Button = ({
-  size = 'sm',
-  prefix,
-  suffix,
-  inverted,
-  sx,
-  children,
-  align,
-  href,
-  internal,
-  tracking,
-  ...props
-}) => {
+const Button = (
+  {
+    size = 'sm',
+    prefix,
+    suffix,
+    inverted,
+    sx,
+    children,
+    align,
+    href,
+    internal,
+    tracking,
+    ...props
+  },
+  ref
+) => {
   if (!['xs', 'sm', 'md', 'lg', 'xl'].includes(size)) {
     throw new Error('Size must be xs, sm, md, lg, or xl')
   }
@@ -187,6 +190,7 @@ const Button = ({
   if (href) {
     return (
       <Link
+        ref={ref}
         href={href}
         internal={internal}
         tracking={tracking}
@@ -201,11 +205,11 @@ const Button = ({
     )
   } else {
     return (
-      <Box as='button' sx={style} {...props}>
+      <Box ref={ref} as='button' sx={style} {...props}>
         {Inner}
       </Box>
     )
   }
 }
 
-export default Button
+export default forwardRef(Button)

--- a/src/callout.js
+++ b/src/callout.js
@@ -1,19 +1,12 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { Box } from 'theme-ui'
 import { Arrow } from '@carbonplan/icons'
 import Link from './link'
 
-const Callout = ({
-  label,
-  children,
-  inverted,
-  color,
-  href,
-  internal,
-  tracking,
-  sx,
-  ...props
-}) => {
+const Callout = (
+  { label, children, inverted, color, href, internal, tracking, sx, ...props },
+  ref
+) => {
   const baseColor = color || (inverted ? 'secondary' : 'primary')
   const hoverColor = color ? 'primary' : inverted ? 'primary' : 'secondary'
 
@@ -86,6 +79,7 @@ const Callout = ({
   if (href) {
     return (
       <Link
+        ref={ref}
         href={href}
         internal={internal}
         tracking={tracking}
@@ -97,11 +91,11 @@ const Callout = ({
     )
   } else {
     return (
-      <Box as='button' sx={style} {...props}>
+      <Box ref={ref} as='button' sx={style} {...props}>
         {Inner}
       </Box>
     )
   }
 }
 
-export default Callout
+export default forwardRef(Callout)

--- a/src/input.js
+++ b/src/input.js
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { Input as ThemedInput } from 'theme-ui'
 import getSizeStyles from './utils/get-size-styles'
 
-const Input = ({ size = 'sm', inverted, sx, ...props }) => {
+const Input = ({ size = 'sm', inverted, sx, ...props }, ref) => {
   const defaultColor = inverted ? 'secondary' : 'primary'
 
   const styles = {
@@ -35,7 +35,7 @@ const Input = ({ size = 'sm', inverted, sx, ...props }) => {
     ...getSizeStyles(size),
     ...sx,
   }
-  return <ThemedInput {...props} sx={styles} />
+  return <ThemedInput {...props} ref={ref} sx={styles} />
 }
 
-export default Input
+export default forwardRef(Input)

--- a/src/link.js
+++ b/src/link.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { Link as ThemedLink } from 'theme-ui'
 import { default as NextLink } from 'next/link'
 
@@ -15,17 +15,16 @@ const event = ({ action, category, label, value }) => {
   })
 }
 
-const Link = ({
-  href,
-  children,
-  internal = false,
-  tracking = false,
-  ...props
-}) => {
+const Link = (
+  { href, children, internal = false, tracking = false, ...props },
+  ref
+) => {
   if (internal || (href && href.startsWith('/'))) {
     return (
       <NextLink href={href} passHref>
-        <ThemedLink {...props}>{children}</ThemedLink>
+        <ThemedLink ref={ref} {...props}>
+          {children}
+        </ThemedLink>
       </NextLink>
     )
   } else if (tracking) {
@@ -46,17 +45,23 @@ const Link = ({
       })
     }
     return (
-      <ThemedLink onClick={track} onContextMenu={track} href={href} {...props}>
+      <ThemedLink
+        ref={ref}
+        onClick={track}
+        onContextMenu={track}
+        href={href}
+        {...props}
+      >
         {children}
       </ThemedLink>
     )
   } else {
     return (
-      <ThemedLink href={href} {...props}>
+      <ThemedLink ref={ref} href={href} {...props}>
         {children}
       </ThemedLink>
     )
   }
 }
 
-export default Link
+export default forwardRef(Link)

--- a/src/slider.js
+++ b/src/slider.js
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { useThemeUI, Slider as ThemeSlider } from 'theme-ui'
 
-const Slider = ({ sx, ...props }) => {
+const Slider = ({ sx, ...props }, ref) => {
   const color = sx && sx.color ? sx.color : 'primary'
   const {
     theme: { rawColors: colors },
@@ -9,6 +9,7 @@ const Slider = ({ sx, ...props }) => {
 
   return (
     <ThemeSlider
+      ref={ref}
       sx={{
         '&::-webkit-slider-thumb': {
           height: [22, 18, 16],
@@ -43,4 +44,4 @@ const Slider = ({ sx, ...props }) => {
   )
 }
 
-export default Slider
+export default forwardRef(Slider)

--- a/src/toggle.js
+++ b/src/toggle.js
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 import { Box } from 'theme-ui'
 import { transparentize } from '@theme-ui/color'
 
-const Toggle = ({ value, onClick, disabled, sx, ...props }, forwardRef) => {
+const Toggle = ({ value, onClick, disabled, sx, ...props }, ref) => {
   const color = sx && sx.color ? sx.color : 'primary'
   value = disabled ? false : value
   return (

--- a/src/toggle.js
+++ b/src/toggle.js
@@ -1,12 +1,13 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { Box } from 'theme-ui'
 import { transparentize } from '@theme-ui/color'
 
-const Toggle = ({ value, onClick, disabled, sx, ...props }) => {
+const Toggle = ({ value, onClick, disabled, sx, ...props }, forwardRef) => {
   const color = sx && sx.color ? sx.color : 'primary'
   value = disabled ? false : value
   return (
     <Box
+      ref={ref}
       as='button'
       onClick={onClick}
       role='checkbox'
@@ -53,4 +54,4 @@ const Toggle = ({ value, onClick, disabled, sx, ...props }) => {
   )
 }
 
-export default Toggle
+export default forwardRef(Toggle)


### PR DESCRIPTION
This PR adds `ref` forwarding on a few of our components, namely the ones for which we will occasionally need to access the underlying DOM element, e.g. `button` or `input`. I've tested it in the context of an app that required this feature and its working great.