### PR TITLE
adjustable clims

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/components",
-  "version": "10.4.0",
+  "version": "10.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/components",
-      "version": "10.4.0",
+      "version": "10.5.0",
       "license": "MIT",
       "dependencies": {
         "@carbonplan/emoji": "^1.0.0",

--- a/src/colorbar.js
+++ b/src/colorbar.js
@@ -1,12 +1,28 @@
-import React from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { Box, Flex } from 'theme-ui'
 
 const sx = {
-  clim: {
-    fontFamily: 'mono',
-    fontSize: ['9px', 0, 0, 1],
-    letterSpacing: 'smallcaps',
-    textTransform: 'uppercase',
+  clim: (setClim) => {
+    return {
+      fontFamily: 'mono',
+      fontSize: ['9px', 0, 0, 1],
+      letterSpacing: 'smallcaps',
+      textTransform: 'uppercase',
+      '&:hover': {
+        borderBottom: setClim
+          ? ({ colors }) => `solid 1px ${colors.primary} !important`
+          : 'unset',
+      },
+      '&:focus': {
+        outline: 'none',
+        borderBottom: setClim
+          ? ({ colors }) => `solid 1px ${colors.primary} !important`
+          : 'unset',
+      },
+      transition: 'border 0.15s',
+      userSelect: setClim ? 'none !important' : 'unset',
+      width: 'fit-content',
+    }
   },
 }
 
@@ -86,27 +102,142 @@ const Colorbar = ({
   colormap,
   label,
   clim,
+  setClim,
+  setClimStep = 1,
   discrete,
   units,
   width,
   height,
   format = (d) => d,
   horizontal = false,
+  bottom = false,
   ...props
 }) => {
   if (!Array.isArray(colormap)) {
     throw new Error(`expected array for colormap, got '${colormap}'.`)
   }
 
+  const climRef = [useRef(), useRef()]
+  const [climMinDragging, setClimMinDragging] = useState(false)
+  const [climMaxDragging, setClimMaxDragging] = useState(false)
+
+  let x,
+    y,
+    dx,
+    dy = 0
+  let id = null
+  let init = [0, 0]
+  let scale = setClimStep
+
+  const draggingFunction = (e) => {
+    if (id === 'min' && !climMinDragging) setClimMinDragging(true)
+    if (id === 'max' && !climMaxDragging) setClimMaxDragging(true)
+    dx = e.pageX - x
+    dy = e.pageY - y
+    if (horizontal) {
+      if (id === 'min')
+        setClim((prev) => [Math.min(init[0] + dx * scale, init[1]), prev[1]])
+      if (id === 'max')
+        setClim((prev) => [prev[0], Math.max(init[1] + dx * scale, init[0])])
+    } else {
+      if (id === 'min')
+        setClim((prev) => [Math.min(init[0] - dy * scale, init[1]), prev[1]])
+      if (id === 'max')
+        setClim((prev) => [prev[0], Math.max(init[1] - dy * scale, init[0])])
+    }
+  }
+
+  const handleMouseDown = (e) => {
+    y = e.pageY
+    x = e.pageX
+    id = e.target.id
+    init = clim
+
+    document.body.setAttribute(
+      'style',
+      horizontal
+        ? 'cursor: ew-resize !important'
+        : 'cursor: ns-resize !important'
+    )
+    document.addEventListener('mousemove', draggingFunction)
+    const updater = () => {
+      document.body.setAttribute('style', 'cursor: unset')
+      document.removeEventListener('mousemove', draggingFunction)
+      window.removeEventListener('mouseup', updater)
+      if (id === 'min') setClimMinDragging(false)
+      if (id === 'max') setClimMaxDragging(false)
+    }
+    window.addEventListener('mouseup', updater)
+  }
+
+  const increment = (e) => {
+    if (climRef[0].current === document.activeElement) {
+      e.preventDefault()
+      setClim((prev) => [Math.min(prev[0] + scale, prev[1]), prev[1]])
+      climRef[0].current.focus()
+    }
+    if (climRef[1].current === document.activeElement) {
+      e.preventDefault()
+      setClim((prev) => [prev[0], Math.max(prev[1] + scale, prev[0])])
+      climRef[1].current.focus()
+    }
+  }
+
+  const decrement = (e) => {
+    if (climRef[0].current === document.activeElement) {
+      e.preventDefault()
+      setClim((prev) => [Math.min(prev[0] - scale, prev[1]), prev[1]])
+      climRef[0].current.focus()
+    }
+    if (climRef[1].current === document.activeElement) {
+      e.preventDefault()
+      setClim((prev) => [prev[0], Math.max(prev[1] - scale, prev[0])])
+      climRef[1].current.focus()
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener('keydown', (e) => {
+      if (
+        ['ArrowUp', 'ArrowRight'].includes(e.code) ||
+        ['ArrowUp', 'ArrowRight'].includes(e.key)
+      ) {
+        increment(e)
+      }
+      if (
+        ['ArrowDown', 'ArrowLeft'].includes(e.code) ||
+        ['ArrowDown', 'ArrowLeft'].includes(e.key)
+      ) {
+        decrement(e)
+      }
+    })
+  }, [])
+
   const ClimMin = () => {
     return (
       <Box
+        id='min'
+        ref={climRef[0]}
+        tabIndex={0}
         sx={{
-          ...sx.clim,
-          ml: label ? (horizontal ? '10px' : '2px') : 0,
+          ...sx.clim(setClim),
+          ml: label ? (horizontal ? (bottom ? '0px' : '10px') : '2px') : 0,
           mr: horizontal ? ['2px', '1px', '1px', '2px'] : 0,
           mb: horizontal ? 0 : ['-2px', '-2px', '-2px', '-3px'],
+          borderBottom: setClim
+            ? climMinDragging
+              ? ({ colors }) => `solid 1px ${colors.primary}`
+              : ({ colors }) => `solid 1px ${colors.secondary}`
+            : 'unset',
+
+          cursor: setClim
+            ? horizontal
+              ? 'ew-resize'
+              : 'ns-resize'
+            : 'default',
         }}
+        onMouseDown={setClim ? handleMouseDown : () => {}}
+        onClick={() => climRef[0].current.focus()}
       >
         {format(clim[0])}
       </Box>
@@ -116,11 +247,26 @@ const Colorbar = ({
   const ClimMax = () => {
     return (
       <Box
+        id='max'
+        ref={climRef[1]}
+        tabIndex={0}
         sx={{
-          ...sx.clim,
+          ...sx.clim(setClim),
           ml: horizontal ? ['2px', '1px', '1px', '2px'] : '2px',
           mt: horizontal ? 0 : ['-2px', '-3px', '-3px', '-3px'],
+          borderBottom: setClim
+            ? climMaxDragging
+              ? ({ colors }) => `solid 1px ${colors.primary}`
+              : ({ colors }) => `solid 1px ${colors.secondary}`
+            : 'unset',
+          cursor: setClim
+            ? horizontal
+              ? 'ew-resize'
+              : 'ns-resize'
+            : 'default',
         }}
+        onMouseDown={setClim ? handleMouseDown : () => {}}
+        onClick={() => climRef[1].current.focus()}
       >
         {format(clim[1])}
       </Box>
@@ -132,22 +278,31 @@ const Colorbar = ({
       sx={{
         ...props.sx,
         flexDirection: 'row',
-        alignItems: 'center',
+        alignItems: 'start',
         justifyContent: 'flex-start',
         gap: ['3px', '6px', '6px', '7px'],
       }}
     >
       {label && <Label label={label} units={units} horizontal={horizontal} />}
-
-      {horizontal && clim && <ClimMin />}
-      <Gradient
-        colormap={colormap}
-        horizontal={horizontal}
-        discrete={discrete}
-        width={width}
-        height={height}
-      />
-      {horizontal && clim && <ClimMax />}
+      <Flex sx={{ flexDirection: 'column', ml: bottom ? '4px' : '0px' }}>
+        <Flex sx={{ gap: ['3px', '6px', '6px', '7px'] }}>
+          {horizontal && clim && !bottom && <ClimMin />}
+          <Gradient
+            colormap={colormap}
+            horizontal={horizontal}
+            discrete={discrete}
+            width={width}
+            height={height}
+          />
+          {horizontal && clim && !bottom && <ClimMax />}
+        </Flex>
+        {horizontal && clim && bottom && (
+          <Flex sx={{ justifyContent: 'space-between' }}>
+            <ClimMin />
+            <ClimMax />
+          </Flex>
+        )}
+      </Flex>
 
       {!horizontal && (
         <Flex

--- a/src/colorbar.js
+++ b/src/colorbar.js
@@ -8,10 +8,12 @@ const sx = {
       fontSize: ['9px', 0, 0, 1],
       letterSpacing: 'smallcaps',
       textTransform: 'uppercase',
-      '&:hover': {
-        borderBottom: setClim
-          ? ({ colors }) => `solid 1px ${colors.primary} !important`
-          : 'unset',
+      '@media (hover: hover) and (pointer: fine)': {
+        '&:hover': {
+          borderBottom: setClim
+            ? ({ colors }) => `solid 1px ${colors.primary} !important`
+            : 'unset',
+        },
       },
       '&:focus': {
         outline: 'none',
@@ -22,6 +24,7 @@ const sx = {
       transition: 'border 0.15s',
       userSelect: setClim ? 'none !important' : 'unset',
       width: 'fit-content',
+      minWidth: 'fit-content',
     }
   },
 }
@@ -111,6 +114,7 @@ const Colorbar = ({
   format = (d) => d,
   horizontal = false,
   bottom = false,
+  sxClim = {},
   ...props
 }) => {
   if (!Array.isArray(colormap)) {
@@ -197,7 +201,7 @@ const Colorbar = ({
   }
 
   useEffect(() => {
-    window.addEventListener('keydown', (e) => {
+    const listener = (e) => {
       if (
         ['ArrowUp', 'ArrowRight'].includes(e.code) ||
         ['ArrowUp', 'ArrowRight'].includes(e.key)
@@ -210,8 +214,13 @@ const Colorbar = ({
       ) {
         decrement(e)
       }
-    })
-  }, [])
+    }
+    window.addEventListener('keydown', listener)
+
+    return () => {
+      window.removeEventListener('keydown', listener)
+    }
+  }, [clim])
 
   const ClimMin = () => {
     return (
@@ -229,12 +238,12 @@ const Colorbar = ({
               ? ({ colors }) => `solid 1px ${colors.primary}`
               : ({ colors }) => `solid 1px ${colors.secondary}`
             : 'unset',
-
           cursor: setClim
             ? horizontal
               ? 'ew-resize'
               : 'ns-resize'
             : 'default',
+          ...sxClim,
         }}
         onMouseDown={setClim ? handleMouseDown : () => {}}
         onClick={() => climRef[0].current.focus()}
@@ -264,6 +273,7 @@ const Colorbar = ({
               ? 'ew-resize'
               : 'ns-resize'
             : 'default',
+          ...sxClim,
         }}
         onMouseDown={setClim ? handleMouseDown : () => {}}
         onClick={() => climRef[1].current.focus()}
@@ -284,7 +294,13 @@ const Colorbar = ({
       }}
     >
       {label && <Label label={label} units={units} horizontal={horizontal} />}
-      <Flex sx={{ flexDirection: 'column', ml: bottom ? '4px' : '0px' }}>
+      <Flex
+        sx={{
+          flexGrow: 1,
+          flexDirection: 'column',
+          ml: bottom && label ? '4px' : '0px',
+        }}
+      >
         <Flex sx={{ gap: ['3px', '6px', '6px', '7px'] }}>
           {horizontal && clim && !bottom && <ClimMin />}
           <Gradient

--- a/src/colorbar.js
+++ b/src/colorbar.js
@@ -291,17 +291,24 @@ const Colorbar = ({
         alignItems: 'start',
         justifyContent: 'flex-start',
         gap: ['3px', '6px', '6px', '7px'],
+        height: !horizontal ? '100%' : 'unset',
       }}
     >
       {label && <Label label={label} units={units} horizontal={horizontal} />}
       <Flex
         sx={{
-          flexGrow: 1,
+          flexGrow: horizontal ? 1 : 'unset',
           flexDirection: 'column',
           ml: bottom && label ? '4px' : '0px',
+          height: !horizontal ? '100%' : 'unset',
         }}
       >
-        <Flex sx={{ gap: ['3px', '6px', '6px', '7px'] }}>
+        <Flex
+          sx={{
+            gap: ['3px', '6px', '6px', '7px'],
+            height: !horizontal ? '100%' : 'unset',
+          }}
+        >
           {horizontal && clim && !bottom && <ClimMin />}
           <Gradient
             colormap={colormap}

--- a/src/select.js
+++ b/src/select.js
@@ -4,7 +4,7 @@ import { Arrow } from '@carbonplan/icons'
 import getProps from './utils/get-props'
 import getSizeStyles from './utils/get-size-styles'
 
-const Select = ({ children, size = 'sm', sx, ...props }) => {
+const Select = ({ children, size = 'sm', sx, sxSelect, ...props }) => {
   const color = sx && sx.color ? sx.color : 'primary'
   const sizeStyles = getSizeStyles(size)
   const ref = useRef(null)
@@ -79,6 +79,7 @@ const Select = ({ children, size = 'sm', sx, ...props }) => {
               background: 'transparent !important',
             },
           },
+          ...sxSelect,
         }}
         {...omitOnChange}
       >


### PR DESCRIPTION
This PR adds new functionality to the `Colorbar` component: the ability to manipulate the color limits.

Here's a demo:
![CleanShot 2021-12-22 at 18 18 24](https://user-images.githubusercontent.com/3387500/147183200-6021ff4b-89e8-4dc5-ae3c-0253849046da.gif)

The design is loosely inspired by Figma. The only API change is to handle two additional props, `setClim` and `setClimStep`.

```
const colormap = useThemedColormap('warm')
const [clim, setClim] = useState([0, 10])
return (
  <Colorbar
    colormap={colormap}
    units={'units'}
    label={'Label'}
    clim={clim}
    setClim={setClim}
  />
```

For keyboard use, both limits are tabbable, at which point the arrow keys can be used for adjustment.

Without `clim` specified, the colorbar is rendered exactly as it was previously.

In addition, to support a layout that may be common with adjustable limits, the new `bottom` prop when used alongside `horizontal` will result in the following (in this case no label or units are provided).

<img width="145" alt="CleanShot 2021-12-22 at 19 10 56@2x" src="https://user-images.githubusercontent.com/3387500/147183578-ddb22b43-3758-446b-94ee-4626f6495828.png">

All other existing behavior should remain unchanged.

