### PR TITLE
header pointer events

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -122,7 +122,9 @@ const Header = ({ status, mode, nav, menuItems }) => {
       }}
     >
       <Column start={[1]} width={[2]}>
-        <Box sx={{ display: 'block', width: 'fit-content' }}>
+        <Box
+          sx={{ pointerEvents: 'all', display: 'block', width: 'fit-content' }}
+        >
           {(mode == 'homepage' || mode == 'local') && (
             <NextLink href='/' passHref>
               <Link
@@ -176,7 +178,7 @@ const Header = ({ status, mode, nav, menuItems }) => {
         width={[status ? 1 : 3, 3, 2, 2]}
         sx={{ zIndex: 5000 }}
       >
-        <Flex sx={{ justifyContent: 'flex-end' }}>
+        <Flex sx={{ pointerEvents: 'all', justifyContent: 'flex-end' }}>
           <Flex
             sx={{
               mr: '18px',


### PR DESCRIPTION
Tiny PR to add `pointerEvents: 'all'` to the two header elements that are clickable (the logo and the button array). In most use cases this should have no effect. However, in (rare) scenarios where we want to ensure correct z-ordering by putting the header inside a component with a higher z-order and `pointerEvents: 'none'`, we don't want to prevent clicking the individual elements. And it seems extremely unlikely that we would want to use the header at all if these elements weren't  clickable, so it seems like a reasonable style to force.