### PR TITLE
Hide menuItems when status present on Header

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -189,10 +189,11 @@ const Header = ({ status, mode, nav, menuItems }) => {
               alignItems: 'center',
             }}
           >
-            {menuItems}
+            {status ? null : menuItems}
           </Flex>
           <Menu
             sx={{
+              flexShrink: 0,
               mr: ['-2px'],
             }}
             value={expanded}


### PR DESCRIPTION
Fixes bug introduced in https://github.com/carbonplan/components/pull/114 where `Menu` shrinks to accommodate `menuItems` and `status` (or just a lot of `menuItems`). Closes https://github.com/carbonplan/components/issues/122.
- Add `flexShrink: 0` to `Menu` to prevent shrinking
- Also hide `menuItems` when `status` is present
  - Consistent with previous behavior of hiding `Settings` and `Dimmer`
  - Avoids having to position many elements in header

Before
![Screen Shot 2022-01-13 at 3 04 26 PM](https://user-images.githubusercontent.com/12436887/149424909-b58b1992-a9ad-45fd-9f8e-77793f436efe.png)

After
![Screen Shot 2022-01-13 at 3 06 39 PM](https://user-images.githubusercontent.com/12436887/149424912-45b721f0-6025-49fe-bcf4-0c7043463551.png)