### PR TITLE
Update LinkGroup to use Flex

### DIFF
--- a/src/custom-404.js
+++ b/src/custom-404.js
@@ -7,7 +7,13 @@ import Column from './column'
 
 const Custom404 = () => {
   return (
-    <Layout footer={false} title={'404 – CarbonPlan'} description={"Sorry but we can't seem to find the page you are looking for."}>
+    <Layout
+      footer={false}
+      title={'404 – CarbonPlan'}
+      description={
+        "Sorry but we can't seem to find the page you are looking for."
+      }
+    >
       <Row sx={{ mb: [5, 0, 0], pt: [0, 0, 6] }}>
         <Column start={[1, 1, 3, 3]} width={[6, 4, 4, 4]}>
           <Styled.h1>Oops!</Styled.h1>

--- a/src/link-group.js
+++ b/src/link-group.js
@@ -1,7 +1,6 @@
 import React from 'react'
-import { Box } from 'theme-ui'
+import { Flex } from 'theme-ui'
 import { RotatingArrow } from '@carbonplan/icons'
-import Group from './group'
 import Button from './button'
 
 const LinkGroup = ({
@@ -10,12 +9,21 @@ const LinkGroup = ({
   inverted,
   tracking,
   size = 'xs',
+  rowGap = [2, 2, 2, 3],
+  columnGap = [3, 3, 3, 4],
   direction = 'horizontal',
-  spacing = 'sm',
   sx,
 }) => {
   return (
-    <Group direction={direction} spacing={spacing} sx={sx}>
+    <Flex
+      sx={{
+        flexDirection: direction === 'horizontal' ? 'row' : 'column',
+        rowGap,
+        columnGap,
+        flexWrap: 'wrap',
+        ...sx,
+      }}
+    >
       {members.map((d, i) => {
         return (
           <Button
@@ -23,10 +31,7 @@ const LinkGroup = ({
             href={d.href}
             label={d.label}
             size={size}
-            sx={{
-              color: color,
-              mb: [2, 1, 1, 1],
-            }}
+            sx={{ color: color }}
             inverted={inverted}
             suffix={<RotatingArrow />}
             tracking={tracking}
@@ -35,7 +40,7 @@ const LinkGroup = ({
           </Button>
         )
       })}
-    </Group>
+    </Flex>
   )
 }
 


### PR DESCRIPTION
- Updates `LinkGroup` to use `Flex` to manage spacing between `members` that wrap
- Changes default spacing to agree with existing use of `LinkGroup` in `research`