### PR TITLE
Blockquote bugfix

### DIFF
--- a/src/blockquote.js
+++ b/src/blockquote.js
@@ -5,6 +5,7 @@ const specialChars = ['“', '"', "'", '‘']
 
 const Blockquote = ({ children }) => {
   let firstChar = ''
+  let filteredChildren = children
 
   if (
     Array.isArray(children) &&
@@ -12,19 +13,19 @@ const Blockquote = ({ children }) => {
     typeof children[0].props.children === 'string'
   ) {
     firstChar = children[0].props.children.slice(0, 1)
-    children = Children.map(children, (d, i) => {
+    filteredChildren = Children.map(children, (d, i) => {
       if (i == 0) {
         return cloneElement(d, { children: d.props.children.slice(1) })
       } else return d
     })
   } else if (children.props && typeof children.props.children === 'string') {
     firstChar = children.props.children.slice(0, 1)
-    children = cloneElement(children, {
+    filteredChildren = cloneElement(children, {
       children: children.props.children.slice(1),
     })
   } else if (typeof children === 'string') {
     firstChar = children.slice(0, 1)
-    children = children.slice(1)
+    filteredChildren = children.slice(1)
   }
 
   return (
@@ -34,7 +35,7 @@ const Blockquote = ({ children }) => {
           {firstChar}
         </Box>
       )}
-      {children}
+      {specialChars.includes(firstChar) ? filteredChildren : children}
     </Box>
   )
 }


### PR DESCRIPTION
- Only render filtered children when special character present
- Fixes bug when introducing `Blockquote` to `research` in https://github.com/carbonplan/research/pull/243
<img width="1016" alt="Screen Shot 2022-05-03 at 9 59 43 AM" src="https://user-images.githubusercontent.com/12436887/166502735-73e1271c-b15f-471d-8896-6e54b205ae29.png">
