### PR TITLE
Avoid using transparent background-color as default

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -62,7 +62,7 @@ const Select = ({ children, size = 'sm', sx, sxSelect, ...props }) => {
           WebkitAppearance: 'none',
           MozAppearance: 'none',
           pb: ['5px'],
-          bg: 'transparent',
+          bg: 'background',
           pr: pr,
           border: 'none',
           borderBottomStyle: 'solid',


### PR DESCRIPTION
This PR updates the default `background-color` style on the `select` element in `Select` to accommodate browsers like Firefox, which directly apply text color to select options, resulting in unreadable elements in darkmode (see table below).

|Browser|Before|After|
|-|-|-|
|Firefox|<img width="1140" alt="Screen Shot 2022-05-26 at 2 37 21 PM" src="https://user-images.githubusercontent.com/12436887/170585386-5b599193-18b0-405c-8c65-1b46c5d7cfdc.png">|<img width="1139" alt="Screen Shot 2022-05-26 at 2 36 49 PM" src="https://user-images.githubusercontent.com/12436887/170585379-a27cd541-5a44-4116-a595-e43bc914049e.png">|
|Chrome|<img width="882" alt="Screen Shot 2022-05-26 at 2 36 37 PM" src="https://user-images.githubusercontent.com/12436887/170585375-813ec543-6c61-4d1b-a1e6-7aa3821e45dc.png">|unchanged|
|Safari|<img width="1000" alt="Screen Shot 2022-05-26 at 2 36 59 PM" src="https://user-images.githubusercontent.com/12436887/170585382-18983b0f-3c07-4826-b9ea-07eba46b835a.png">|unchanged|


