### PR TITLE
Reorder favicon elements

### DIFF
--- a/src/meta.js
+++ b/src/meta.js
@@ -22,6 +22,11 @@ const Meta = ({ title, description, card }) => {
       <meta name='description' content={descriptionProp} />
       <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       <link
+        rel='alternate icon'
+        type='image/png'
+        href='https://images.carbonplan.org/favicon.png'
+      />
+      <link
         rel='icon'
         type='image/svg+xml'
         href='https://images.carbonplan.org/favicon.svg'
@@ -56,11 +61,6 @@ const Meta = ({ title, description, card }) => {
       />
       <link rel='manifest' href='https://images.carbonplan.org/manifest.json' />
       <meta name='theme-color' content='#1b1e23' />
-      <link
-        rel='alternate icon'
-        type='image/png'
-        href='https://images.carbonplan.org/favicon.png'
-      />
       <link
         rel='mask-icon'
         href='https://images.carbonplan.org/safari-pinned-tab.svg'


### PR DESCRIPTION
This PR adjusts the ordering of the favicon elements so that the PNG version is not repeatedly requested on route changes in modern browsers like Chrome that use the SVG element (see illustration of issue below).

It's not exactly clear why reordering would fix this issue, but this [browser behavior](https://stackoverflow.com/questions/53464667/best-practice-for-ordering-icon-link-tags-in-html-head/53531660#53531660) for interpreting favicon order could potentially be related. The new PNG -> SVG order also agrees with this [Next.js example](https://github.com/vercel/next.js/blob/8783793273425efcc6f5b97cba27b3102fc5b84d/examples/blog-starter/components/meta.tsx#L27). 

![CleanShot 2022-08-03 at 09 46 59](https://user-images.githubusercontent.com/12436887/182674268-0df1c983-498c-4e3a-9dad-8e2f14d4fd0f.gif)
