### PR TITLE
support limit

### DIFF
--- a/src/avatar-group.js
+++ b/src/avatar-group.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Box } from 'theme-ui'
 import Avatar from './avatar'
 import Row from './row'
 import Column from './column'
@@ -12,23 +13,50 @@ const sizes = {
   xl: [9],
 }
 
+const Blank = ({ overflow, maxWidth }) => {
+  return (
+    <Box
+      sx={{
+        bg: 'muted',
+        height: '100%',
+        maxWidth: maxWidth,
+        borderRadius: '50%',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100%',
+        }}
+      >
+        <Box
+          sx={{
+            fontFamily: 'mono',
+            letterSpacing: 'mono',
+            fontSize: [3, 3, 3, 4],
+          }}
+        >
+          +{overflow}
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
 const AvatarGroup = ({
   members,
   direction = 'horizontal',
   align,
   spacing = 'md',
+  limit,
   width,
   maxWidth,
   fixedCount,
   sx,
   ...props
 }) => {
-  if (members.length > fixedCount) {
-    throw Error(
-      `cannot render '${members.length}' avatars with a fixed count of '${fixedCount}'`
-    )
-  }
-
   let gap
   if (sizes.hasOwnProperty(spacing)) {
     gap = sizes[spacing]
@@ -47,12 +75,15 @@ const AvatarGroup = ({
           return 'auto'
         } else if (d === 'right') {
           const offset = Math.max(1, fixedCount - members.length + 1)
-          return offset + idx
+          return (offset + idx) % fixedCount
         } else {
           throw Error(`alignment '${align}' not recognized`)
         }
       })
   }
+
+  let excess = members.length > limit
+  let overflow = members.length - limit + 1
 
   return (
     <>
@@ -60,7 +91,12 @@ const AvatarGroup = ({
         <Row columns={fixedCount} gap={gap} sx={sx} {...props}>
           {members.map((props, idx) => (
             <Column key={idx} start={start(idx)}>
-              <Avatar {...props} width={width} maxWidth={maxWidth} />
+              {(!excess || idx < (limit - 1)) && (
+                <Avatar {...props} width={width} maxWidth={maxWidth} />
+              )}
+              {excess && idx === (limit - 1) && (
+                <Blank overflow={overflow} maxWidth={maxWidth} />
+              )}
             </Column>
           ))}
         </Row>

--- a/src/avatar-group.js
+++ b/src/avatar-group.js
@@ -91,10 +91,10 @@ const AvatarGroup = ({
         <Row columns={fixedCount} gap={gap} sx={sx} {...props}>
           {members.map((props, idx) => (
             <Column key={idx} start={start(idx)}>
-              {(!excess || idx < (limit - 1)) && (
+              {(!excess || idx < limit - 1) && (
                 <Avatar {...props} width={width} maxWidth={maxWidth} />
               )}
-              {excess && idx === (limit - 1) && (
+              {excess && idx === limit - 1 && (
                 <Blank overflow={overflow} maxWidth={maxWidth} />
               )}
             </Column>

--- a/src/avatar-group.js
+++ b/src/avatar-group.js
@@ -82,8 +82,8 @@ const AvatarGroup = ({
       })
   }
 
-  let excess = members.length > limit
-  let overflow = members.length - limit + 1
+  const excess = members.length > limit
+  const overflow = members.length - limit + 1
 
   return (
     <>
@@ -91,10 +91,10 @@ const AvatarGroup = ({
         <Row columns={fixedCount} gap={gap} sx={sx} {...props}>
           {members.map((props, idx) => (
             <Column key={idx} start={start(idx)}>
-              {(!excess || idx < limit - 1) && (
+              {((!limit && !excess) || idx < limit - 1) && (
                 <Avatar {...props} width={width} maxWidth={maxWidth} />
               )}
-              {excess && idx === limit - 1 && (
+              {(limit && excess) && idx === limit - 1 && (
                 <Blank overflow={overflow} maxWidth={maxWidth} />
               )}
             </Column>

--- a/src/avatar-group.js
+++ b/src/avatar-group.js
@@ -94,7 +94,7 @@ const AvatarGroup = ({
               {((!limit && !excess) || idx < limit - 1) && (
                 <Avatar {...props} width={width} maxWidth={maxWidth} />
               )}
-              {(limit && excess) && idx === limit - 1 && (
+              {limit && excess && idx === limit - 1 && (
                 <Blank overflow={overflow} maxWidth={maxWidth} />
               )}
             </Column>


### PR DESCRIPTION
This PR adds support for a `limit` argument. The behavior is as follows: when the number of avatars exceeds the limit, the final avatar is replaced with a circle with the text `+X` where X is the number of avatars not shown. 

As examples, here is a group with a `fixedCount` of `3`, the actual number of avatars is 4, 2, and 3, in the first case the `limit` is set to `2` and in the second it's set to `3`.

<img width="245" alt="CleanShot 2022-09-02 at 10 30 01@2x" src="https://user-images.githubusercontent.com/3387500/188207273-cf6d7922-5cf8-4e38-bc80-a41c8f7fe4e1.png">

<img width="263" alt="CleanShot 2022-09-02 at 10 30 05@2x" src="https://user-images.githubusercontent.com/3387500/188207268-284730a5-cb29-4a1d-85ac-37388d749bee.png">