### PR TITLE
Only restrict overscroll behavior in the Y direction

### DIFF
--- a/globals.css
+++ b/globals.css
@@ -1,5 +1,5 @@
 body {
-  overscroll-behavior: none;
+  overscroll-behavior-y: none;
   text-rendering: optimizeLegibility;
 }
 


### PR DESCRIPTION
Removing overscroll restriction in `x` direction allows Chrome to respond to swipe-to-navigate gestures. In practice, applications only use `y`-based overflow scrolling (where we want to limit bouncing with style). 