### PR TITLE
Fix AvatarGroup right alignment

### DIFF
--- a/src/avatar-group.js
+++ b/src/avatar-group.js
@@ -74,8 +74,8 @@ const AvatarGroup = ({
         if (d === 'left') {
           return 'auto'
         } else if (d === 'right') {
-          const offset = Math.max(1, fixedCount - members.length + 1)
-          return (offset + idx) % fixedCount
+          const offset = Math.max(0, fixedCount - members.length)
+          return ((offset + idx) % fixedCount) + 1
         } else {
           throw Error(`alignment '${align}' not recognized`)
         }


### PR DESCRIPTION
Fix column `start` calculation for `right` alignment so that when `fixedCount=3, idx=0, members.length=1`, `start=3` is calculated instead of `start=0`.

|Before|After|
|-|-|
|![CleanShot 2025-03-20 at 13 59 27@2x](https://github.com/user-attachments/assets/ccc4af99-7bed-4e9d-bd10-0381dbcdf7cc)|![CleanShot 2025-03-20 at 13 59 50@2x](https://github.com/user-attachments/assets/a4e26634-a027-4013-b7e7-10a1cf35f5bb)|