### PR TITLE
fix regression in header width caused by Safari FadeIn fix

### DIFF
--- a/src/fade-in.tsx
+++ b/src/fade-in.tsx
@@ -30,7 +30,7 @@ const FadeIn = ({
         animationDelay: delay + 'ms',
         animationName: fade.toString(),
         animationFillMode: 'backwards',
-        WebkitTransform: 'translateZ(0)',
+        willChange: 'opacity',
       }}
     >
       {children}


### PR DESCRIPTION
This fixes a regression introduced in #193 (Safari fade in fix). 

We fixed an issue visible in offsets-db in Safari where rows wouldn't show up until hovered by adding `TranslateZ(0)` to `FadeIn`. This inadvertently messed with how absolutely positioned elements behave within it, so that the article header bar didn't reach full width in drafts. We get the same safari fix with swapping for `willChange` without messing up how absolutely positioned elements behave downstream. 

I tested the fix in drafts (seeing expected full width bar) and offsets-db (rows all show up in safari with `willChange` and are missing without it). 